### PR TITLE
External ownership

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -206,7 +206,7 @@ impl Bytes {
     ///
     /// A common use case is to zero-copy construct from mapped memory.
     ///
-    /// ```no_run
+    /// ```ignore
     /// use bytes::Bytes;
     /// use std::fs::File;
     /// use memmap2::Map;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1057,8 +1057,6 @@ unsafe fn external_box_and_drop<T>(ptr: *mut ()) {
     drop(b);
 }
 
-
-
 unsafe fn external_clone(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Bytes {
     let external = data.load(Ordering::Acquire);
     let ref_cnt = &(*external.cast::<ExternalLifetime>()).ref_cnt;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1012,6 +1012,73 @@ unsafe fn static_drop(_: &mut AtomicPtr<()>, _: *const u8, _: usize) {
     // nothing to drop for &'static [u8]
 }
 
+// ===== impl ExternalVtable =====
+
+/// Manage the lifetime of a [Bytes] buffer externally.
+///
+/// The trait is marked as `unsafe` since it needs to ensure that the slice
+/// of returned by [AsRef<[u8]>](AsRef) retains a fixed address in memory,
+/// tied the lifetime of the trait implementor.
+///
+/// A common use case for implementing the [ExternalBytesOwner] is when
+/// the memory is owned by external means such as a memory mapped file.
+pub unsafe trait ExternalBytesOwner : Drop + AsRef<[u8]> {}
+
+struct External {
+    owner: *const dyn ExternalBytesOwner,
+    ref_cnt: AtomicUsize,
+}
+
+impl Clone for External {
+    fn clone(&self) -> Self {
+        todo!()
+    }
+}
+
+impl Drop for External {
+    fn drop(&mut self) {
+        todo!()
+    }
+}
+
+unsafe fn external_clone(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Bytes {
+    let external = data.load(Ordering::Acquire);
+    let external = &*external.cast::<External>();
+    todo!()
+}
+
+unsafe fn external_to_vec(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> Vec<u8> {
+    let external = data.load(Ordering::Acquire);
+    let external = &*external.cast::<External>();
+    todo!()
+}
+
+unsafe fn external_to_mut(data: &AtomicPtr<()>, ptr: *const u8, len: usize) -> BytesMut {
+    let external = data.load(Ordering::Acquire);
+    let external = &*external.cast::<External>();
+    todo!()
+}
+
+unsafe fn external_is_unique(data: &AtomicPtr<()>) -> bool {
+    let external = data.load(Ordering::Acquire);
+    let external = &*external.cast::<External>();
+    todo!()
+}
+
+unsafe fn external_drop(data: &mut AtomicPtr<()>, ptr: *const u8, len: usize) {
+    let external = data.load(Ordering::Acquire);
+    let external = &*external.cast::<External>();
+    todo!()
+}
+
+static EXTERNAL_VTABLE: Vtable = Vtable {
+    clone: external_clone,
+    to_vec: external_to_vec,
+    to_mut: external_to_mut,
+    is_unique: external_is_unique,
+    drop: external_drop,
+};
+
 // ===== impl PromotableVtable =====
 
 static PROMOTABLE_EVEN_VTABLE: Vtable = Vtable {

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -13,7 +13,7 @@ use alloc::{
 };
 
 use crate::buf::{IntoIter, UninitSlice};
-use crate::bytes::Vtable;
+use crate::bytes::{shared_is_unique, Vtable};
 #[allow(unused)]
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
@@ -1776,6 +1776,7 @@ static SHARED_VTABLE: Vtable = Vtable {
     to_vec: shared_v_to_vec,
     to_mut: shared_v_to_mut,
     is_unique: shared_v_is_unique,
+    cheap_into_mut: shared_is_unique,
     drop: shared_v_drop,
 };
 

--- a/src/bytes_mut.rs
+++ b/src/bytes_mut.rs
@@ -13,7 +13,7 @@ use alloc::{
 };
 
 use crate::buf::{IntoIter, UninitSlice};
-use crate::bytes::{shared_is_unique, Vtable};
+use crate::bytes::Vtable;
 #[allow(unused)]
 use crate::loom::sync::atomic::AtomicMut;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
@@ -1776,7 +1776,7 @@ static SHARED_VTABLE: Vtable = Vtable {
     to_vec: shared_v_to_vec,
     to_mut: shared_v_to_mut,
     is_unique: shared_v_is_unique,
-    cheap_into_mut: shared_is_unique,
+    cheap_into_mut: shared_v_is_unique,
     drop: shared_v_drop,
 };
 

--- a/tests/test_bytes.rs
+++ b/tests/test_bytes.rs
@@ -1490,7 +1490,6 @@ struct OwnedTester(Rc<Cell<usize>>);
 
 impl Drop for OwnedTester {
     fn drop(&mut self) {
-        eprintln!("OwnedTester.drop :: (A) {:p}", self as *mut Self);
         let current = self.0.get();
         self.0.set(current + 1)
     }
@@ -1538,5 +1537,20 @@ fn owned_to_mut() {
 
     assert_eq!(drop_counter.get(), 1);
     drop(bm1);
+    assert_eq!(drop_counter.get(), 1);
+}
+
+#[test]
+fn owned_to_vec() {
+    let drop_counter = Rc::new(Cell::new(0));
+    let owner = OwnedTester(drop_counter.clone());
+    let b1 = unsafe { Bytes::with_owner(LONG.as_ptr(), LONG.len(), owner) };
+    assert!(b1.is_unique());
+
+    let v1 = b1.to_vec();
+    assert!(b1.is_unique());
+    assert_eq!(&v1[..], &b1[..]);
+
+    drop(b1);
     assert_eq!(drop_counter.get(), 1);
 }


### PR DESCRIPTION
Introduces `Bytes::from_owner`, allowing the creation of a bytes object from another `AsRef<[u8]>` object which is responsible for the ownership of the exposed byte slice.

The core use case is to safely construct from mapped memory.

```rust
use memmap2::Map;

let file = File::open("upload_bundle.tar.gz")?;
let mmap = unsafe { Mmap::map(&file) }?;
let b = Bytes::from_owner(mmap);
```

It should practically address the vast majority of use cases for wanting to expose the VTable as has often been requested in https://github.com/tokio-rs/bytes/issues/437, without actually exposing the VTable.
